### PR TITLE
Adding in notes and changes from final data tests for the stock backtester repo. 4/2/25

### DIFF
--- a/Archive/.ipynb_checkpoints/Data_Loading_From_SSD_Test-checkpoint.ipynb
+++ b/Archive/.ipynb_checkpoints/Data_Loading_From_SSD_Test-checkpoint.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 44,
    "id": "e227afe1-8812-47a4-9362-961bab2a6275",
    "metadata": {},
    "outputs": [],
@@ -34,6 +34,9 @@
     "import dask\n",
     "import dask.dataframe as dd\n",
     "from dask import delayed\n",
+    "from pyarrow.parquet import ParquetFile\n",
+    "import pyarrow as pa\n",
+    "from tqdm import tqdm\n",
     "\n",
     "import tulipy as ti\n",
     "\n",
@@ -96,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 66,
    "id": "f82bb222-4158-4d10-9fd7-341e74b6ac23",
    "metadata": {},
    "outputs": [
@@ -106,7 +109,7 @@
        "'/Volumes/T7/filtered-parquet-PM'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -125,110 +128,465 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 69,
+   "id": "65a29b0b-895a-4b0d-a1f5-902fa31f9bfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_parquet_PM_path_2 = ssd_path + 'filtered-parquet-PM 2/'\n",
+    "filtered_parquet_PM_path_3 = ssd_path + 'filtered-parquet-PM 3/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "78cb67fe-d79a-4c94-a215-c6f7a7a59a21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2990"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(os.listdir(filtered_parquet_PM_path_2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "9f209b60-29f9-4196-b471-010aa0de0683",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1188"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(os.listdir(filtered_parquet_PM_path_3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "f22ac81a-20bd-430b-b059-de67687363ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8552"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.chdir(filtered_parquet_PM_path_3)\n",
+    "len(os.listdir('AAPL_1min_parquet'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "94a65d42-4129-4375-bf4d-03b1bd74409b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4146"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Getting how many folders with tickers there are\n",
+    "len(os.listdir(filtered_parquet_PM_HL_path))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
    "id": "7dbfbf8e-73a0-47cf-a738-c26d5f81c250",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2"
+       "22"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Testing the data with NYT\n",
-    "NYT_parq_folder = 'NYT_1min_parquet'\n",
-    "len(os.listdir(NYT_parq_folder))"
+    "# Testing the data with NTLA\n",
+    "NTLA_parq_folder = 'NTLA_1min_parquet'\n",
+    "len(os.listdir(NTLA_parq_folder))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 53,
    "id": "ce587102-745f-4734-8193-1003680eb53b",
    "metadata": {},
    "outputs": [
     {
-     "ename": "ArrowInvalid",
-     "evalue": "An error occurred while calling the read_parquet method registered to the pandas backend.\nOriginal Message: Error creating dataset. Could not read schema from '/Volumes/T7/filtered-parquet-PM/MDT_1min_parquet/._2005-11-14_MDT_1min.parquet'. Is this a 'parquet' file?: Could not open Parquet input source '/Volumes/T7/filtered-parquet-PM/MDT_1min_parquet/._2005-11-14_MDT_1min.parquet': Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mArrowInvalid\u001b[0m                              Traceback (most recent call last)",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/dask/backends.py:136\u001b[0m, in \u001b[0;36mCreationDispatch.register_inplace.<locals>.decorator.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    135\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 136\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m func(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[1;32m    137\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/dask/dataframe/io/parquet/core.py:538\u001b[0m, in \u001b[0;36mread_parquet\u001b[0;34m(path, columns, filters, categories, index, storage_options, engine, use_nullable_dtypes, dtype_backend, calculate_divisions, ignore_metadata_file, metadata_task_size, split_row_groups, blocksize, aggregate_files, parquet_file_extension, filesystem, **kwargs)\u001b[0m\n\u001b[1;32m    536\u001b[0m     blocksize \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 538\u001b[0m read_metadata_result \u001b[38;5;241m=\u001b[39m engine\u001b[38;5;241m.\u001b[39mread_metadata(\n\u001b[1;32m    539\u001b[0m     fs,\n\u001b[1;32m    540\u001b[0m     paths,\n\u001b[1;32m    541\u001b[0m     categories\u001b[38;5;241m=\u001b[39mcategories,\n\u001b[1;32m    542\u001b[0m     index\u001b[38;5;241m=\u001b[39mindex,\n\u001b[1;32m    543\u001b[0m     use_nullable_dtypes\u001b[38;5;241m=\u001b[39muse_nullable_dtypes,\n\u001b[1;32m    544\u001b[0m     dtype_backend\u001b[38;5;241m=\u001b[39mdtype_backend,\n\u001b[1;32m    545\u001b[0m     gather_statistics\u001b[38;5;241m=\u001b[39mcalculate_divisions,\n\u001b[1;32m    546\u001b[0m     filters\u001b[38;5;241m=\u001b[39mfilters,\n\u001b[1;32m    547\u001b[0m     split_row_groups\u001b[38;5;241m=\u001b[39msplit_row_groups,\n\u001b[1;32m    548\u001b[0m     blocksize\u001b[38;5;241m=\u001b[39mblocksize,\n\u001b[1;32m    549\u001b[0m     aggregate_files\u001b[38;5;241m=\u001b[39maggregate_files,\n\u001b[1;32m    550\u001b[0m     ignore_metadata_file\u001b[38;5;241m=\u001b[39mignore_metadata_file,\n\u001b[1;32m    551\u001b[0m     metadata_task_size\u001b[38;5;241m=\u001b[39mmetadata_task_size,\n\u001b[1;32m    552\u001b[0m     parquet_file_extension\u001b[38;5;241m=\u001b[39mparquet_file_extension,\n\u001b[1;32m    553\u001b[0m     dataset\u001b[38;5;241m=\u001b[39mdataset_options,\n\u001b[1;32m    554\u001b[0m     read\u001b[38;5;241m=\u001b[39mread_options,\n\u001b[1;32m    555\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mother_options,\n\u001b[1;32m    556\u001b[0m )\n\u001b[1;32m    558\u001b[0m \u001b[38;5;66;03m# In the future, we may want to give the engine the\u001b[39;00m\n\u001b[1;32m    559\u001b[0m \u001b[38;5;66;03m# option to return a dedicated element for `common_kwargs`.\u001b[39;00m\n\u001b[1;32m    560\u001b[0m \u001b[38;5;66;03m# However, to avoid breaking the API, we just embed this\u001b[39;00m\n\u001b[1;32m    561\u001b[0m \u001b[38;5;66;03m# data in the first element of `parts` for now.\u001b[39;00m\n\u001b[1;32m    562\u001b[0m \u001b[38;5;66;03m# The logic below is inteded to handle backward and forward\u001b[39;00m\n\u001b[1;32m    563\u001b[0m \u001b[38;5;66;03m# compatibility with a user-defined engine.\u001b[39;00m\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/dask/dataframe/io/parquet/arrow.py:536\u001b[0m, in \u001b[0;36mArrowDatasetEngine.read_metadata\u001b[0;34m(cls, fs, paths, categories, index, use_nullable_dtypes, dtype_backend, gather_statistics, filters, split_row_groups, blocksize, aggregate_files, ignore_metadata_file, metadata_task_size, parquet_file_extension, **kwargs)\u001b[0m\n\u001b[1;32m    535\u001b[0m \u001b[38;5;66;03m# Stage 1: Collect general dataset information\u001b[39;00m\n\u001b[0;32m--> 536\u001b[0m dataset_info \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mcls\u001b[39m\u001b[38;5;241m.\u001b[39m_collect_dataset_info(\n\u001b[1;32m    537\u001b[0m     paths,\n\u001b[1;32m    538\u001b[0m     fs,\n\u001b[1;32m    539\u001b[0m     categories,\n\u001b[1;32m    540\u001b[0m     index,\n\u001b[1;32m    541\u001b[0m     gather_statistics,\n\u001b[1;32m    542\u001b[0m     filters,\n\u001b[1;32m    543\u001b[0m     split_row_groups,\n\u001b[1;32m    544\u001b[0m     blocksize,\n\u001b[1;32m    545\u001b[0m     aggregate_files,\n\u001b[1;32m    546\u001b[0m     ignore_metadata_file,\n\u001b[1;32m    547\u001b[0m     metadata_task_size,\n\u001b[1;32m    548\u001b[0m     parquet_file_extension,\n\u001b[1;32m    549\u001b[0m     kwargs,\n\u001b[1;32m    550\u001b[0m )\n\u001b[1;32m    552\u001b[0m \u001b[38;5;66;03m# Stage 2: Generate output `meta`\u001b[39;00m\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/dask/dataframe/io/parquet/arrow.py:1051\u001b[0m, in \u001b[0;36mArrowDatasetEngine._collect_dataset_info\u001b[0;34m(cls, paths, fs, categories, index, gather_statistics, filters, split_row_groups, blocksize, aggregate_files, ignore_metadata_file, metadata_task_size, parquet_file_extension, kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m ds \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m-> 1051\u001b[0m     ds \u001b[38;5;241m=\u001b[39m pa_ds\u001b[38;5;241m.\u001b[39mdataset(\n\u001b[1;32m   1052\u001b[0m         paths,\n\u001b[1;32m   1053\u001b[0m         filesystem\u001b[38;5;241m=\u001b[39m_wrapped_fs(fs),\n\u001b[1;32m   1054\u001b[0m         \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39m_processed_dataset_kwargs,\n\u001b[1;32m   1055\u001b[0m     )\n\u001b[1;32m   1057\u001b[0m \u001b[38;5;66;03m# Get file_frag sample and extract physical_schema\u001b[39;00m\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pyarrow/dataset.py:785\u001b[0m, in \u001b[0;36mdataset\u001b[0;34m(source, schema, format, filesystem, partitioning, partition_base_dir, exclude_invalid_files, ignore_prefixes)\u001b[0m\n\u001b[1;32m    784\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mall\u001b[39m(_is_path_like(elem) \u001b[38;5;28;01mfor\u001b[39;00m elem \u001b[38;5;129;01min\u001b[39;00m source):\n\u001b[0;32m--> 785\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m _filesystem_dataset(source, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[1;32m    786\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28mall\u001b[39m(\u001b[38;5;28misinstance\u001b[39m(elem, Dataset) \u001b[38;5;28;01mfor\u001b[39;00m elem \u001b[38;5;129;01min\u001b[39;00m source):\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pyarrow/dataset.py:475\u001b[0m, in \u001b[0;36m_filesystem_dataset\u001b[0;34m(source, schema, filesystem, partitioning, format, partition_base_dir, exclude_invalid_files, selector_ignore_prefixes)\u001b[0m\n\u001b[1;32m    473\u001b[0m factory \u001b[38;5;241m=\u001b[39m FileSystemDatasetFactory(fs, paths_or_selector, \u001b[38;5;28mformat\u001b[39m, options)\n\u001b[0;32m--> 475\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m factory\u001b[38;5;241m.\u001b[39mfinish(schema)\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pyarrow/_dataset.pyx:3016\u001b[0m, in \u001b[0;36mpyarrow._dataset.DatasetFactory.finish\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pyarrow/error.pxi:154\u001b[0m, in \u001b[0;36mpyarrow.lib.pyarrow_internal_check_status\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/pyarrow/error.pxi:91\u001b[0m, in \u001b[0;36mpyarrow.lib.check_status\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mArrowInvalid\u001b[0m: Error creating dataset. Could not read schema from '/Volumes/T7/filtered-parquet-PM/MDT_1min_parquet/._2005-11-14_MDT_1min.parquet'. Is this a 'parquet' file?: Could not open Parquet input source '/Volumes/T7/filtered-parquet-PM/MDT_1min_parquet/._2005-11-14_MDT_1min.parquet': Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file.",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[0;31mArrowInvalid\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[38], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Testing with dask NYT filtered PM parquet data\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m df_NYT \u001b[38;5;241m=\u001b[39m dd\u001b[38;5;241m.\u001b[39mread_parquet(AAOI_parq_folder)\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m# This part is optional (if you want to choose a specific datetime range)\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;66;03m# ^Note, the time range you chose MUST have data in it for this to work\u001b[39;00m\n\u001b[1;32m      7\u001b[0m \u001b[38;5;66;03m# df_NYT = df_NYT.loc['2024-07-15 00:00':'2024-07-30 00:00']\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;66;03m# # Repartioning for 5 days because data is pretty sparse\u001b[39;00m\n\u001b[1;32m     16\u001b[0m \u001b[38;5;66;03m# df_NYT = df_NYT.repartition(freq='5D')\u001b[39;00m\n\u001b[1;32m     18\u001b[0m df_NYT\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.11/site-packages/dask/backends.py:138\u001b[0m, in \u001b[0;36mCreationDispatch.register_inplace.<locals>.decorator.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    136\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m func(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[1;32m    137\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[0;32m--> 138\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;28mtype\u001b[39m(e)(\n\u001b[1;32m    139\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAn error occurred while calling the \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfuncname(func)\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    140\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmethod registered to the \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbackend\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m backend.\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    141\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mOriginal Message: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00me\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    142\u001b[0m     ) \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01me\u001b[39;00m\n",
-      "\u001b[0;31mArrowInvalid\u001b[0m: An error occurred while calling the read_parquet method registered to the pandas backend.\nOriginal Message: Error creating dataset. Could not read schema from '/Volumes/T7/filtered-parquet-PM/MDT_1min_parquet/._2005-11-14_MDT_1min.parquet'. Is this a 'parquet' file?: Could not open Parquet input source '/Volumes/T7/filtered-parquet-PM/MDT_1min_parquet/._2005-11-14_MDT_1min.parquet': Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file."
-     ]
+     "data": {
+      "text/html": [
+       "<div><strong>Dask DataFrame Structure:</strong></div>\n",
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Open</th>\n",
+       "      <th>High</th>\n",
+       "      <th>Low</th>\n",
+       "      <th>Close</th>\n",
+       "      <th>Volume</th>\n",
+       "      <th>Ticker</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>npartitions=516</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2017-11-02 04:03:00</th>\n",
+       "      <td>float64</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>string</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-11-05 00:00:00</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2024-11-18 00:00:00</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2024-11-18 15:59:00</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<div>Dask Name: repartition-merge, 8 graph layers</div>"
+      ],
+      "text/plain": [
+       "Dask DataFrame Structure:\n",
+       "                        Open     High      Low    Close   Volume  Ticker\n",
+       "npartitions=516                                                         \n",
+       "2017-11-02 04:03:00  float64  float64  float64  float64  float64  string\n",
+       "2017-11-05 00:00:00      ...      ...      ...      ...      ...     ...\n",
+       "...                      ...      ...      ...      ...      ...     ...\n",
+       "2024-11-18 00:00:00      ...      ...      ...      ...      ...     ...\n",
+       "2024-11-18 15:59:00      ...      ...      ...      ...      ...     ...\n",
+       "Dask Name: repartition-merge, 8 graph layers"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Testing with dask NYT filtered PM parquet data\n",
-    "df_NYT = dd.read_parquet(AAOI_parq_folder)\n",
+    "# Testing with dask NTLA filtered PM parquet data\n",
+    "df_NTLA = dd.read_parquet(NTLA_parq_folder)\n",
     "\n",
     "\n",
     "# This part is optional (if you want to choose a specific datetime range)\n",
     "# ^Note, the time range you chose MUST have data in it for this to work\n",
-    "# df_NYT = df_NYT.loc['2024-07-15 00:00':'2024-07-30 00:00']\n",
-    "# df_NYT = df_NYT.loc['2024-12-01 00:00':'2024-12-30 00:00']\n",
+    "# df_NTLA = df_NTLA.loc['2024-07-15 00:00':'2024-07-30 00:00']\n",
+    "# df_NTLA = df_NTLA.loc['2024-12-01 00:00':'2024-12-30 00:00']\n",
     "\n",
     "# Need to do the following to repartition properly\n",
-    "# df_NYT = df_NYT.reset_index()\n",
-    "# df_NYT['timestamp'] = df_NYT['timestamp'].dt.floor('s')\n",
-    "# df_NYT = df_NYT.set_index('timestamp')\n",
+    "df_NTLA = df_NTLA.reset_index()\n",
+    "df_NTLA['timestamp'] = df_NTLA['timestamp'].dt.floor('s')\n",
+    "df_NTLA = df_NTLA.set_index('timestamp')\n",
     "\n",
     "# # Repartioning for 5 days because data is pretty sparse\n",
-    "# df_NYT = df_NYT.repartition(freq='5D')\n",
+    "df_NTLA = df_NTLA.repartition(freq='5D')\n",
     "\n",
-    "df_NYT"
+    "df_NTLA"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 65,
+   "id": "41ef9933-d7c8-45ef-a393-063781d2b1d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Open</th>\n",
+       "      <th>High</th>\n",
+       "      <th>Low</th>\n",
+       "      <th>Close</th>\n",
+       "      <th>Volume</th>\n",
+       "      <th>Ticker</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>timestamp</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2021-06-28 04:06:00</th>\n",
+       "      <td>130.00</td>\n",
+       "      <td>130.0000</td>\n",
+       "      <td>130.00</td>\n",
+       "      <td>130.0000</td>\n",
+       "      <td>295.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-28 04:07:00</th>\n",
+       "      <td>125.00</td>\n",
+       "      <td>125.0000</td>\n",
+       "      <td>123.99</td>\n",
+       "      <td>123.9900</td>\n",
+       "      <td>238.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-28 04:08:00</th>\n",
+       "      <td>123.99</td>\n",
+       "      <td>123.9900</td>\n",
+       "      <td>123.99</td>\n",
+       "      <td>123.9900</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-28 04:09:00</th>\n",
+       "      <td>121.99</td>\n",
+       "      <td>122.0000</td>\n",
+       "      <td>121.99</td>\n",
+       "      <td>122.0000</td>\n",
+       "      <td>200.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-28 04:10:00</th>\n",
+       "      <td>122.00</td>\n",
+       "      <td>122.0000</td>\n",
+       "      <td>122.00</td>\n",
+       "      <td>122.0000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-30 15:55:00</th>\n",
+       "      <td>163.65</td>\n",
+       "      <td>163.9399</td>\n",
+       "      <td>162.83</td>\n",
+       "      <td>163.0200</td>\n",
+       "      <td>37309.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-30 15:56:00</th>\n",
+       "      <td>163.21</td>\n",
+       "      <td>163.4000</td>\n",
+       "      <td>161.58</td>\n",
+       "      <td>161.9499</td>\n",
+       "      <td>58386.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-30 15:57:00</th>\n",
+       "      <td>161.91</td>\n",
+       "      <td>162.2800</td>\n",
+       "      <td>161.56</td>\n",
+       "      <td>162.0700</td>\n",
+       "      <td>80103.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-30 15:58:00</th>\n",
+       "      <td>162.11</td>\n",
+       "      <td>162.5900</td>\n",
+       "      <td>161.99</td>\n",
+       "      <td>162.4199</td>\n",
+       "      <td>63782.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021-06-30 15:59:00</th>\n",
+       "      <td>162.42</td>\n",
+       "      <td>162.5100</td>\n",
+       "      <td>161.63</td>\n",
+       "      <td>161.8199</td>\n",
+       "      <td>123506.0</td>\n",
+       "      <td>NTLA</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1419 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       Open      High     Low     Close    Volume Ticker\n",
+       "timestamp                                                               \n",
+       "2021-06-28 04:06:00  130.00  130.0000  130.00  130.0000     295.0   NTLA\n",
+       "2021-06-28 04:07:00  125.00  125.0000  123.99  123.9900     238.0   NTLA\n",
+       "2021-06-28 04:08:00  123.99  123.9900  123.99  123.9900       0.0   NTLA\n",
+       "2021-06-28 04:09:00  121.99  122.0000  121.99  122.0000     200.0   NTLA\n",
+       "2021-06-28 04:10:00  122.00  122.0000  122.00  122.0000       0.0   NTLA\n",
+       "...                     ...       ...     ...       ...       ...    ...\n",
+       "2021-06-30 15:55:00  163.65  163.9399  162.83  163.0200   37309.0   NTLA\n",
+       "2021-06-30 15:56:00  163.21  163.4000  161.58  161.9499   58386.0   NTLA\n",
+       "2021-06-30 15:57:00  161.91  162.2800  161.56  162.0700   80103.0   NTLA\n",
+       "2021-06-30 15:58:00  162.11  162.5900  161.99  162.4199   63782.0   NTLA\n",
+       "2021-06-30 15:59:00  162.42  162.5100  161.63  161.8199  123506.0   NTLA\n",
+       "\n",
+       "[1419 rows x 6 columns]"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_NTLA.partitions[250:300].compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
    "id": "8c19d2d5-d765-424c-81dc-3fd81e1fc0d3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2024-02-20    720\n",
-       "2022-11-22    718\n",
-       "2023-04-24    717\n",
-       "2015-02-17    716\n",
-       "2014-06-16    711\n",
-       "             ... \n",
-       "2008-01-09    480\n",
-       "2007-03-05    480\n",
-       "2007-08-01    480\n",
-       "2007-11-06    480\n",
-       "2007-10-15    480\n",
-       "Name: count, Length: 62, dtype: int64"
+       "2024-11-18    720\n",
+       "2020-06-03    718\n",
+       "2017-11-02    717\n",
+       "2021-06-28    714\n",
+       "2020-12-02    710\n",
+       "2021-06-30    705\n",
+       "2022-12-01    623\n",
+       "2024-10-24    612\n",
+       "2022-08-03    563\n",
+       "2023-11-01    540\n",
+       "2022-09-16    536\n",
+       "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_NYT = pd.read_parquet(AAOI_parq_folder)\n",
-    "pd.DataFrame(df_NYT.index.date).value_counts()"
+    "df_NTLA = pd.read_parquet(NTLA_parq_folder)\n",
+    "pd.DataFrame(df_NTLA.index.date).value_counts()"
    ]
   },
   {

--- a/Archive/Data_Loading_From_SSD_Test.ipynb
+++ b/Archive/Data_Loading_From_SSD_Test.ipynb
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 79,
    "id": "f22ac81a-20bd-430b-b059-de67687363ec",
    "metadata": {},
    "outputs": [
@@ -191,7 +191,7 @@
        "8552"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
**The following are the final notes that would have gone into the stock backtester repo, but are now placed here since I transferred over repos.**

Dask time-series alterations:
- Found out that you need to use a dt.floor(‘S’) or dt.floor(‘s’) function to get your dask df into a time-series before you can repartition (tested with df_AAOI):
```
df_AAOI = df_AAOI.reset_index()
df_AAOI['timestamp'] = df_AAOI['timestamp'].dt.floor('S')
df_AAOI = df_AAOI.set_index('timestamp')
df_AAOI = df_AAOI.repartition(freq='10D')
```
- Got the repartitioning of dd.read_parquet() files to work as well (along with dd.read_csv())

Data cleaning issues:
- Found out a data cleaning problem where some dates don’t have data at 3:55pm, so needed to re-clean it to make sure there’s data all the way up to 3:55pm (did this in the previous notebook
- Tested this with a few of the beginning stocks, and found a few (e.g., AAPL on 11/26/2004 where there weren’t any candles after a certain time (and definitely no candles at 15:59))
- Just realized that this is likely just holidays, so we’re essentially just filling in this information for the backtester
- Practically, this doesn’t matter much because it’s not fulfilling any of the BHOD conditions, but it’s good to have cleaned data all the way up to 15:59pm just in case there are any tickers that don’t have that data

Metrics function update and data backtesting with PM data:
- Made a change to dask_to_var_vol_metrics() function where the combined metrics table only takes in not df.empty dfs AND not None dfs
- Tested entire MSFT dataset and found that it did quite poorly overall; when shifting to just the 3y time frame as we did previously, results were similar, even with the PM-filtered data
- Also tested with 3y TSLA dataset, and win ratio was actually worse for the filtered stocks (though it was still positive technically)
- Win ratio for both MSFT and TSLA was close to 60%

Data download:
- Downloaded filtered-PM data onto an SSD drive to use
- Moved code over to local notebook with SSD drive
- Cleaned up some of the functions for local code (and made it easier overall to use)
